### PR TITLE
Initial pass on plugin documentations

### DIFF
--- a/docs/building_the_mtable.rst
+++ b/docs/building_the_mtable.rst
@@ -100,70 +100,44 @@ this will give you an answer like:
 
 .. code-block:: json
 
-{
-  "took": 7,
-  "timed_out": false,
-  "_shards": {
-    "total": 5,
-    "successful": 5,
-    "skipped": 0,
-    "failed": 0
-  },
-  "hits": {
-    "total": 3,
-    "max_score": 1,
-    "hits": [
-      {
-        "_index": ".fs_store",
-        "_type": "store",
-        "_id": "name(0.5,0.1,5)",
-        "_score": 1,
-        "_source": {
-          "name": "test",
-          "type": "mtable",
-          "proportion": 0.5,
-          "alpha": 0.1,
-          "k": 5,
-          "mtable": [
-            0,
-            0,
-            0,
-            0,
-            1,
-            1
-          ]
-        }
-      },
+    {
+        "took": 7,
+        "timed_out": false,
+        "_shards": {
+        "total": 5,
+        "successful": 5,
+        "skipped": 0,
+        "failed": 0
+    },
+    "hits": {
+        "total": 3,
+        "max_score": 1,
+        "hits": [
+        {
+            "_index": ".fs_store",
+            "_type": "store",
+            "_id": "name(0.5,0.1,5)",
+            "_score": 1,
+            "_source": {
+                "name": "test",
+                "type": "mtable",
+                "proportion": 0.5,
+                "alpha": 0.1,
+                "k": 5,
+                "mtable": [
+                 0,
+                 0,
+                 0,
+                 0,
+                 1,
+                 1
+                 ]
+            }
+        },
     ....
-      {
-        "_index": ".fs_store",
-        "_type": "store",
-        "_id": "name(0.6,0.2,10)",
-        "_score": 1,
-        "_source": {
-          "name": "test",
-          "type": "mtable",
-          "proportion": 0.6,
-          "alpha": 0.2,
-          "k": 10,
-          "mtable": [
-            0,
-            0,
-            1,
-            1,
-            2,
-            2,
-            3,
-            3,
-            4,
-            4,
-            5
-          ]
+        ]
         }
-      }
-    ]
-  }
-}
+    }
 
 
 =======================

--- a/docs/building_the_mtable.rst
+++ b/docs/building_the_mtable.rst
@@ -143,3 +143,7 @@ this will give you an answer like:
 =======================
 Delete stored M tables
 =======================
+
+Currently there is no functionality offered to delete an specific mtable, you should probably also never do that yourself.
+However if you want to delete documents, use the standard document api from elastic and refer to the specific table
+document id.

--- a/docs/building_the_mtable.rst
+++ b/docs/building_the_mtable.rst
@@ -44,6 +44,8 @@ for example:
 
     POST /_fs/_mtable/test/0.5/0.1/5
 
+.. code-block:: json
+
     {
         "_index": ".fs_store",
         "_type": "store",
@@ -62,6 +64,7 @@ for example:
 
 this will store a document in elasticsearch that will look like:
 
+.. code-block:: json
 
       {
         "_index": ".fs_store",

--- a/docs/building_the_mtable.rst
+++ b/docs/building_the_mtable.rst
@@ -1,4 +1,48 @@
 Building M tables
 *******************************
 
-M Tables
+The m tables are a core component of this plugin setup, as described in the original paper it describe the fairness
+representation conditions for each use case.
+
+    Specifically, the ranked group fairness criterion compares the
+    number of protected elements in every prex of the ranking, with
+    the expected number of protected elements if they were picked at
+    random using Bernoulli trials. The criterion is based on a statistical
+    test, and we include a signicance parameter (α) corresponding to
+    the probability of rejecting a fair ranking (i.e., a Type I error).
+
+
+    Definition 3.1 (Fair representation condition). Let F (x;n,p) be
+    the cumulative distribution function for a binomial distribution of
+    parameters n and p. A set τ ⊆ Tk,n, having τp protected candidates
+    fairly represents the protected group with minimal proportion p
+    and signicance α, if F (τp ; k,p) > α
+
+from the original paper.
+
+In the plugin we operationalize this process by creating them inside elasticsearch as documents in their own internal store,
+otherwise the process of calculating them on every request would it be very costly.
+
+
+=======================
+Create a new M table
+=======================
+
+To create a new M table you can issue the next command:
+
+    POST /_fs/_mtable/test/0.5/0.1/5
+
+
+=======================
+List all stored M tables
+=======================
+
+To list all stored M tables you can use this command:
+
+    GET _fs/_mtable
+
+
+
+=======================
+Delete stored M tables
+=======================

--- a/docs/building_the_mtable.rst
+++ b/docs/building_the_mtable.rst
@@ -30,8 +30,60 @@ Create a new M table
 
 To create a new M table you can issue the next command:
 
+    POST _fs/_mtable/{name}/{proportion}/{alpha}/{k}
+
+where the parameters are:
+
+* name: A name to attach to this given collection of fairness tables.
+* proportion: The proportion of protected elements.
+* alpha: The significance parameter (α) corresponding to the probability of rejecting a fair ranking.
+* k: The expected size of returned documents in the search.
+
+
+for example:
+
     POST /_fs/_mtable/test/0.5/0.1/5
 
+    {
+        "_index": ".fs_store",
+        "_type": "store",
+        "_id": "name(0.5,0.1,5)",
+        "_version": 1,
+        "result": "created",
+        "forced_refresh": true,
+        "_shards": {
+            "total": 2,
+            "successful": 1,
+            "failed": 0
+        },
+        "_seq_no": 0,
+        "_primary_term": 1
+    }
+
+this will store a document in elasticsearch that will look like:
+
+
+      {
+        "_index": ".fs_store",
+        "_type": "store",
+        "_id": "name(0.5,0.1,5)",
+        "_score": 1,
+        "_source": {
+          "name": "test",
+          "type": "mtable",
+          "proportion": 0.5,
+          "alpha": 0.1,
+          "k": 5,
+          "mtable": [
+            0,
+            0,
+            0,
+            0,
+            1,
+            1
+          ]
+        }
+      }
 
 =======================
 List all stored M tables

--- a/docs/building_the_mtable.rst
+++ b/docs/building_the_mtable.rst
@@ -99,6 +99,7 @@ To list all stored M tables you can use this command:
 this will give you an answer like:
 
 .. code-block:: json
+
 {
   "took": 7,
   "timed_out": false,

--- a/docs/building_the_mtable.rst
+++ b/docs/building_the_mtable.rst
@@ -96,6 +96,73 @@ To list all stored M tables you can use this command:
 
     GET _fs/_mtable
 
+this will give you an answer like:
+
+.. code-block:: json
+{
+  "took": 7,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": 3,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": ".fs_store",
+        "_type": "store",
+        "_id": "name(0.5,0.1,5)",
+        "_score": 1,
+        "_source": {
+          "name": "test",
+          "type": "mtable",
+          "proportion": 0.5,
+          "alpha": 0.1,
+          "k": 5,
+          "mtable": [
+            0,
+            0,
+            0,
+            0,
+            1,
+            1
+          ]
+        }
+      },
+    ....
+      {
+        "_index": ".fs_store",
+        "_type": "store",
+        "_id": "name(0.6,0.2,10)",
+        "_score": 1,
+        "_source": {
+          "name": "test",
+          "type": "mtable",
+          "proportion": 0.6,
+          "alpha": 0.2,
+          "k": 10,
+          "mtable": [
+            0,
+            0,
+            1,
+            1,
+            2,
+            2,
+            3,
+            3,
+            4,
+            4,
+            5
+          ]
+        }
+      }
+    ]
+  }
+}
 
 
 =======================

--- a/docs/building_the_mtable.rst
+++ b/docs/building_the_mtable.rst
@@ -1,0 +1,4 @@
+Building M tables
+*******************************
+
+M Tables

--- a/docs/core-concepts.rst
+++ b/docs/core-concepts.rst
@@ -1,0 +1,4 @@
+Core Concepts
+*******************************
+
+Welcome! You're here if you're interested in adding machine learning ranking capabilities to your Elasticsearch system. This guidebook is intended for Elasticsearch developers and data scientists.

--- a/docs/doing_a_fair_rescoring.rst
+++ b/docs/doing_a_fair_rescoring.rst
@@ -2,3 +2,33 @@ Having a fair rescoring
 *******************************
 
 You got to the end of the documentation, now is time to finally run a fair top-k rescoring.
+
+The usual flow for a fair search is this one:
+
+* a user execute a query in the search engine, however during this process s/he also
+* select the UI s/he wants to retrieve a fair search.
+
+To achive this we are going to use the rescoring functionality provided by elasticsearch.
+
+Your request will look something like:
+
+.. code-block:: json
+
+    GET test/_search
+    {
+        "query": {
+            "match_all": {}
+        },
+        "rescore": {
+            "fair_rescorer": {
+                "protected_key": "gender",
+                "protected_value": "Female",
+                "significance_level": 0.1,
+                "min_proportion_protected": 0.5
+            }
+        }
+    }
+
+this request is actually doing a match_all query, could it by any other type of elasticsearch query, for example a bool
+or a multi match. then after the results are calculated (in every shard) it apply the fair rescoring algorithm. This
+request will give you a response where the target number of protected elements will be scored in relevant places.

--- a/docs/doing_a_fair_rescoring.rst
+++ b/docs/doing_a_fair_rescoring.rst
@@ -1,0 +1,4 @@
+Having a fair rescoring
+*******************************
+
+You got to the end of the documentation, now is time to finally run a fair top-k rescoring.

--- a/docs/fits-in.rst
+++ b/docs/fits-in.rst
@@ -16,3 +16,11 @@ ethnic minorities, or an under-represented gender in a specic industry).
 This plugin is here to help your search produce a fair ranking given one legally-protected attribute, i.e.,
 a ranking in which the representation of the minority group does not fall below a minimum proportion p at any point in the ranking,
 while the utility of the ranking is maintained as high as possible.
+
+
+=======================
+What the plugin is NOT
+=======================
+
+This plugin does not help you select the best proportion and significant parameters for your use case, you will need
+to experiment and find the best correlation of them for your case.

--- a/docs/fits-in.rst
+++ b/docs/fits-in.rst
@@ -1,4 +1,18 @@
 How does the plugin fit in?
 ******************************
 
-In :doc:`core-concepts` we mentioned a couple of activities you undertake when implementing learning to rank:
+In :doc:`core-concepts` we mentioned the different building parts of this plugin, in this section we are going to
+describe where to this plugin fits in.
+
+=======================
+What the plugin does
+=======================
+
+People search engines, as a main example of this plugin application, are not aware of the biases the traditional algorithms
+for search (aka TF/IDF or BM25) might be introducing in their search results. This will reduce the visibility of already
+disadvantaged groups corresponding to a legally protected category such as people with disabilities, racial or
+ethnic minorities, or an under-represented gender in a specic industry).
+
+This plugin is here to help your search produce a fair ranking given one legally-protected attribute, i.e.,
+a ranking in which the representation of the minority group does not fall below a minimum proportion p at any point in the ranking,
+while the utility of the ranking is maintained as high as possible.

--- a/docs/fits-in.rst
+++ b/docs/fits-in.rst
@@ -1,0 +1,4 @@
+How does the plugin fit in?
+******************************
+
+In :doc:`core-concepts` we mentioned a couple of activities you undertake when implementing learning to rank:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,10 +37,10 @@ Contents
 
 
 .. toctree::
-:maxdepth: 2
-core-concepts
-fits-in
-:caption: Contents:
+   :maxdepth: 2
+   core-concepts
+   fits-in
+   :caption: Contents:
 
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Contents
 
 .. toctree::
    :maxdepth: 2
+
    core-concepts
    fits-in
    :caption: Contents:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,8 @@ Get started
 
 - Brand new? head to :doc:`core-concepts`.
 - Otherwise, start with :doc:`fits-in`
+- Building an m table, head to :doc:`building_the_mtable`
+
 
 Installing
 -----------
@@ -41,6 +43,7 @@ Contents
 
    core-concepts
    fits-in
+   building_the_mtable
    :caption: Contents:
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,42 @@
 Elasticsearch Fair search: the documentation
 ==========================================================
 
-Elasticsearch Fair search documentation
+The Elasticsearch fair search plugin apply innovative fair topk ranking algorithms to retrieve a fair set of candidates from your search. This plugin has been develop in collaboration between the TU Berlin, the Pompeu Fabra University and Pere Urbón.
+
+Get started
+-------------------------------
+
+- Brand new? head to :doc:`core-concepts`.
+- Otherwise, start with :doc:`fits-in`
+
+Installing
+-----------
+
+Pre-built versions can be found `here <https://fair-search.github.io/>`_. Want a build for an ES version? Follow the instructions in the `README for building <https://github.com/fair-search/fairsearch-elasticsearch-plugin#development>`_ or `create an issue <https://github.com/fair-search/fairsearch-elasticsearch-plugin/issues>`_. Once you've found a version compatible with your Elasticsearch, you'd run a command such as:
+
+    ./bin/elasticsearch-plugin install \
+    https://fair-search.github.io/fair-reranker/fairsearch-1.0-es6.1.2-SNAPSHOT.zip
+
+(It's expected you'll confirm some security exceptions, you can pass -b to elasticsearch-plugin to automatically install)
+
+
+HEEELP!
+------------------------------
+
+The plugin and guide was built by the search and data consultant  `Pere Urbon <http://purbon.com>`_ in partnership with the TU Berlin and the Pompeu Fabra University. Please `contact Pere Urbon <mailto:name.surname@acm.org>`_ or `create an issue <https://github.com/fair-search/fairsearch-elasticsearch-plugin/issues>`_ if you have any questions or feedback.
+
+
+
+Contents
+-------------------------------
+
+
+.. toctree::
+:maxdepth: 2
+core-concepts
+fits-in
+:caption: Contents:
+
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Get started
 - Brand new? head to :doc:`core-concepts`.
 - Otherwise, start with :doc:`fits-in`
 - Building an m table, head to :doc:`building_the_mtable`
-
+- Doing fair rescoring, head to :doc:`doing_a_fair_rescoring`
 
 Installing
 -----------
@@ -44,6 +44,7 @@ Contents
    core-concepts
    fits-in
    building_the_mtable
+   doing_a_fair_rescoring
    :caption: Contents:
 
 


### PR DESCRIPTION
This PR adds an initial pass on the plugin documentation, you can see how do they look at http://fairsearch-elasticsearch.readthedocs.io/en/feature-docs/index.html
